### PR TITLE
Reduce size of the docker image by 1/3. Security patches as well

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,45 @@
-FROM node:20.5-alpine
+# Base image with Node.js
+FROM node:20.5-alpine AS base
+
+# Set working directory for the build
 WORKDIR /app
-RUN mkdir /app/build
-COPY build /app/build
-COPY package.json /app
-RUN npm i
-CMD ["node", "/app/build"]
+
+# Copy package.json and yarn.lock files (if yarn.lock exists)
+COPY package.json yarn.lock* ./
+
+# Install dependencies
+# This step is separate to take advantage of Docker layer caching
+RUN yarn install --frozen-lockfile
+
+# Copy the rest of your SvelteKit app's source code
+COPY . .
+
+# Build the SvelteKit app
+# Adjust the memory limit based on your specific requirements.
+# This example uses 1 GB.
+# If you don't need to set a memory limit, you can remove the
+# set the deploy target to node
+RUN NODE_OPTIONS="--max-old-space-size=1024" DEPLOY_TARGET=node yarn build
+
+# Create a new stage for running the app
+FROM node:18-alpine AS runner
+
+# Set working directory
+WORKDIR /app
+
+# Don't run production as root - create a non-root user
+RUN addgroup --system --gid 1001 nodejs \
+    && adduser --system --uid 1001 svelte
+
+USER svelte
+
+# Copy the built app and the necessary node modules from the builder stage
+COPY --from=base /app/package.json .
+COPY --from=base /app/build ./build
+COPY --from=base /app/node_modules ./node_modules
+
+# Expose the port the app runs on
+EXPOSE 3000
+
+# Start the SvelteKit app
+CMD [ "node", "build" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3"
+
+services:
+  raga:
+    container_name: raga
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: always
+    ports:
+      - 3000:3000
+    networks:
+      - raga-network
+
+# Define a network, which allows containers to communicate
+# with each other, by using their container name as a hostname
+networks:
+  raga-network:
+    driver: bridge


### PR DESCRIPTION
### Reduced the size of the docker image by 1/3.
Done this by splitting up the build install and serving process and run each in their own container. If you don't know i install the dependecies in one container, move only the needed parts to its own container and serve it.
I usually program in a monorepo. with it i could cut down the image by half, but pity your project is not one.

### Increased security.
it doesn't server as root(security risk). it creates a user
